### PR TITLE
Exposed Color type from Core.roc

### DIFF
--- a/package/Core.roc
+++ b/package/Core.roc
@@ -1,6 +1,7 @@
 module [
     # ANSI
     Escape,
+    Color,
     toStr,
     style,
     color,
@@ -26,9 +27,11 @@ module [
     upperToStr,
 ]
 
-import Color exposing [Color]
+import Color
 import Style exposing [Style]
 import Control exposing [Control]
+
+Color : Color.Color
 
 ## [Ansi Escape Codes](https://en.wikipedia.org/wiki/ANSI_escape_code)
 Escape : [


### PR DESCRIPTION
Rather than expose the full Color module and increase the number of modules exposed (which is currently very minimal) I chose to simply add the `Color` type as an exposed type inside Core.roc.