### PR TITLE
Update examples for platform template 1.0.0

### DIFF
--- a/examples/animals.roc
+++ b/examples/animals.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
 }
 
@@ -8,6 +8,7 @@ import pf.Stdout
 with_color : Str, Str, Str -> Str
 with_color = |text, fg, bg| "\u(001b)[${fg}m\u(001b)[${bg}m${text}\u(001b)[0m"
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
 	parts = [
 		"The ",
@@ -19,6 +20,6 @@ main! = |_args| {
 		" ant shared a leaf.",
 	]
 
-	Stdout.line!(Str.join_with(parts, ""))
+	Stdout.line!(Str.join_with(parts, ""))?
 	Ok({})
 }

--- a/examples/colors.roc
+++ b/examples/colors.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
 }
 
@@ -8,6 +8,7 @@ import pf.Stdout
 with_color : Str, Str, Str -> Str
 with_color = |text, fg, bg| "\u(001b)[${fg}m\u(001b)[${bg}m${text}\u(001b)[0m"
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
 	lines = [
 		with_color("Default color", "39", "49"),
@@ -28,6 +29,6 @@ main! = |_args| {
 		with_color("{ fg: ElectricPurple, bg: Tangerine }", "38;2;153;50;204", "48;2;255;165;0"),
 	]
 
-	Stdout.line!(Str.join_with(lines, "\n"))
+	Stdout.line!(Str.join_with(lines, "\n"))?
 	Ok({})
 }

--- a/examples/styles.roc
+++ b/examples/styles.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
 }
 
@@ -8,6 +8,7 @@ import pf.Stdout
 with_style : Str, Str -> Str
 with_style = |text, code| "\u(001b)[${code}m${text}\u(001b)[0m"
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
 	lines = [
 		with_style("Bold On", "1"),
@@ -20,6 +21,6 @@ main! = |_args| {
 		"This should not have any style",
 	]
 
-	Stdout.line!(Str.join_with(lines, "\n"))
+	Stdout.line!(Str.join_with(lines, "\n"))?
 	Ok({})
 }

--- a/examples/tests.roc
+++ b/examples/tests.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
 }
 
@@ -9,15 +9,19 @@ import ansi.C256
 import ansi.PieceTable
 import ansi.Rgb
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
-	Stdout.line!("Run `roc test examples/tests.roc` to exercise the roc-ansi package examples.")
+	Stdout.line!("Run `roc test examples/tests.roc` to exercise the roc-ansi package examples.")?
 	Ok({})
 }
 
+## ANSI 256 color code 55 converts to its RGB triplet.
 expect C256.to_rgb(55) == (95, 0, 175)
 
+## Hex color parsing keeps the expected teal RGB channels.
 expect Rgb.from_hex(0x008080) == (0, 128, 128)
 
+## Arrow key input renders a readable description.
 expect ANSI.input_to_str(ANSI.Input.Arrow(ANSI.Arrow.Up)) == "Arrow Up"
 
 base_table : PieceTable.PieceTable(U8)
@@ -27,4 +31,5 @@ base_table = {
 	table: [PieceTable.Entry.Original({ start: 0, len: 3 })],
 }
 
+## Inserting into a piece table preserves surrounding bytes.
 expect PieceTable.to_list(PieceTable.insert(base_table, { values: Str.to_utf8("X"), index: 1 })) == Str.to_utf8("aXbc")

--- a/examples/text-editor.roc
+++ b/examples/text-editor.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
 }
 
@@ -13,6 +13,7 @@ to_str = |table|
 		Err(_) => "<invalid utf8>"
 	}
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
 	original = Str.to_utf8("hello terminal")
 	table0 : PieceTable.PieceTable(U8)
@@ -25,6 +26,6 @@ main! = |_args| {
 	table1 = PieceTable.insert(table0, { values: Str.to_utf8(" colorful"), index: 5 })
 	table2 = PieceTable.delete(table1, { index: 0 })
 
-	Stdout.line!("Piece table preview: ${to_str(table2)}")
+	Stdout.line!("Piece table preview: ${to_str(table2)}")?
 	Ok({})
 }

--- a/examples/tui-menu.roc
+++ b/examples/tui-menu.roc
@@ -1,5 +1,5 @@
 app [main!] {
-	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
+	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
 }
 
@@ -20,6 +20,7 @@ menu_line = |label, selected| {
 	}
 }
 
+main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
 	lines = [
 		with_style("Choose a task", "1"),
@@ -31,6 +32,6 @@ main! = |_args| {
 		with_color("ENTER to run, ESC to quit", "34", "49"),
 	]
 
-	Stdout.line!(Str.join_with(lines, "\n"))
+	Stdout.line!(Str.join_with(lines, "\n"))?
 	Ok({})
 }

--- a/package/ANSI.roc
+++ b/package/ANSI.roc
@@ -343,12 +343,13 @@ ANSI := [].{
 
 	parse_cursor : List(U8) -> CursorPosition
 	parse_cursor = |bytes| {
-		{ val: row, rest: after_first } = take_number({ val: 0, rest: List.drop_first(bytes, 2) })
-		{ val: col, .. } = take_number({ val: 0, rest: List.drop_first(after_first, 1) })
+		{ val: row, rest: after_first } = take_number({ val: 0, rest: bytes.drop_first(2) })
+		{ val: col, .. } = take_number({ val: 0, rest: after_first.drop_first(1) })
 
 		{ row, col }
 	}
 
+	update_cursor : { cursor : CursorPosition, screen : ScreenSize }, Arrow -> { cursor : CursorPosition, screen : ScreenSize }
 	update_cursor = |state, direction|
 		match direction {
 			Up =>
@@ -389,6 +390,7 @@ ANSI := [].{
 			}
 
 	## Loop through each pixel in the screen and build up a single string to write to stdout.
+	draw_screen : { cursor : CursorPosition, screen : ScreenSize }, List(DrawFn) -> Str
 	draw_screen = |{ cursor, screen }, draw_fns| {
 		rows = draw_rows(cursor, screen, draw_fns, 0, List.with_capacity(U16.to_u64(screen.height)))
 		join_all_pixels(rows)
@@ -489,10 +491,12 @@ style_code_parts = |codes, out|
 		[code, .. as rest] => style_code_parts(rest, out.append(code.to_str()))
 	}
 
-reset_style : Str
 reset_style = "\u(001b)[0m"
 
+## Raw arrow-up bytes parse as an up arrow input.
 expect ANSI.parse_raw_stdin([27, 91, 65]) == Arrow(Up)
+
+## A bare escape byte parses as an escape action.
 expect ANSI.parse_raw_stdin([27]) == Action(Escape)
 
 ctrl_to_str : ANSI.Ctrl -> Str
@@ -563,6 +567,7 @@ number_to_str = |number|
 		N9 => "9"
 	}
 
+## Cursor-position escape bytes parse row and column numbers.
 expect ANSI.parse_cursor([27, 91, 51, 51, 59, 49, 82]) == { row: 33, col: 1 }
 
 draw_rows : ANSI.CursorPosition, ANSI.ScreenSize, List(ANSI.DrawFn), U16, List(List(ANSI.Pixel)) -> List(List(ANSI.Pixel))
@@ -606,8 +611,13 @@ take_number = |input|
 		_ => input
 	}
 
+## Number parsing leaves non-digit input untouched.
 expect take_number({ val: 0, rest: [27, 91, 51, 51, 59, 49, 82] }) == { val: 0, rest: [27, 91, 51, 51, 59, 49, 82] }
+
+## Number parsing consumes consecutive digit bytes.
 expect take_number({ val: 0, rest: [51, 51, 59, 49, 82] }) == { val: 33, rest: [59, 49, 82] }
+
+## Number parsing stops after the final digit.
 expect take_number({ val: 0, rest: [49, 82] }) == { val: 1, rest: [82] }
 
 join_all_pixels : List(List(ANSI.Pixel)) -> Str
@@ -620,7 +630,7 @@ join_all_pixels = |rows| {
 		styles: [],
 	}
 
-	Str.join_with(List.fold_with_index(rows, init, join_pixel_row).lines, "")
+	Str.join_with(rows.fold_with_index(init, join_pixel_row).lines, "")
 }
 
 join_pixel_row :

--- a/package/C256.roc
+++ b/package/C256.roc
@@ -11,7 +11,7 @@ C256 := U8.{
 		code = U8.to_u64(color)
 
 		if code < 16 {
-			match List.get(system_range, code) {
+			match system_range.get(code) {
 				Ok(rgb) => rgb
 				Err(_) => (0, 0, 0)
 			}
@@ -24,7 +24,7 @@ C256 := U8.{
 					_ => 1
 				}
 
-				match List.get(chromatic_range, (index // divisor) % 6) {
+				match chromatic_range.get((index // divisor) % 6) {
 					Ok(value) => value
 					Err(_) => 0
 				}
@@ -33,7 +33,7 @@ C256 := U8.{
 			(c(0), c(1), c(2))
 		} else {
 			index = code - 232
-			gray = match List.get(grayscale_range, index) {
+			gray = match grayscale_range.get(index) {
 				Ok(value) => value
 				Err(_) => 0
 			}
@@ -94,8 +94,13 @@ grayscale_range = [
 	238,
 ]
 
+## ANSI 256 color code 8 is bright black.
 expect C256.to_rgb(8) == (128, 128, 128)
+
+## ANSI 256 color code 55 is a purple chromatic cube entry.
 expect C256.to_rgb(55) == (95, 0, 175)
+
+## ANSI 256 color code 240 is a grayscale entry.
 expect C256.to_rgb(240) == (88, 88, 88)
 
 # TODO: toC16 : C256 -> C16

--- a/package/Layout.roc
+++ b/package/Layout.roc
@@ -356,26 +356,38 @@ test_rows = [
 	["106", "Microwave", "Appliances", "150", "250", "2004"],
 ]
 
-expect Layout.data_to_rows(test_data, (7, 6)) == Ok(test_rows)
+## Flat data converts into row-major table rows.
+expect {
+	rows = Layout.data_to_rows(test_data, (7, 6))?
+	rows == test_rows
+}
 
-expect Layout.data_to_columns(test_data, (7, 6)) == Ok(
-	[
+## Flat data converts into column-major table columns.
+expect {
+	columns = Layout.data_to_columns(test_data, (7, 6))?
+	columns == [
 		["ProductID", "101", "102", "103", "104", "105", "106"],
 		["ProductName", "Laptop", "Smartphone", "Office Chair", "Coffee Maker", "Desk Lamp", "Microwave"],
 		["Category", "Electronics", "Electronics", "Furniture", "Appliances", "Lighting", "Appliances"],
 		["Price", "1200", "800", "150", "100", "50", "150"],
 		["StockQuantity", "50", "150", "300", "200", "500", "250"],
 		["SupplierID", "2001", "2002", "2003", "2004", "2005", "2004"],
-	],
-)
+	]
+}
 
+## Row drawing truncates cells to the requested widths.
 expect Layout.draw_row(["ProductID", "ProductName", "Category", "Price", "StockQuantity"], [0, 1, 2, 3, 4], Layout.squared_border.base, Layout.default_row_spacing) == "││…│C…│Pr…│Sto…│"
 
+## Squared border rows use square corner glyphs.
 expect Layout.draw_row([], [1, 0], Layout.squared_border.start, Layout.default_row_spacing) == "┌─┬┐"
+
+## Rounded border rows use rounded corner glyphs.
 expect Layout.draw_row([], [1, 0], Layout.rounded_border.end, Layout.default_row_spacing) == "╰─┴╯"
 
+## Auto sizing estimates widths from table content.
 expect Layout.auto_sizes(test_rows) == [3, 12, 11, 5, 4, 4]
 
+## Grid drawing renders rows with squared borders.
 expect Layout.draw_grid([["Apple", "Banana", "Cat"], ["Dog", "Elephant", "Fish"]], [2, 2, 2], Layout.squared_border, Layout.default_spacing) == Str.join_with(
 	[
 		"┌──┬──┬──┐",
@@ -387,6 +399,7 @@ expect Layout.draw_grid([["Apple", "Banana", "Cat"], ["Dog", "Elephant", "Fish"]
 	"\n",
 )
 
+## Grid drawing applies configured margins.
 expect Layout.draw_grid([["Apple", "Banana", "Cat"], ["Dog", "Elephant", "Fish"]], [2, 2, 2], Layout.squared_border, { mx: (1, 2), my: (1, 2), px: (0, 0), py: (0, 0) }) == Str.join_with(
 	[
 		"░░░░░░░░░░░░░",
@@ -401,6 +414,7 @@ expect Layout.draw_grid([["Apple", "Banana", "Cat"], ["Dog", "Elephant", "Fish"]
 	"\n",
 )
 
+## Table drawing includes header and body rows with the pretty border.
 expect Layout.draw_table(test_rows, Layout.auto_sizes(test_rows), Layout.pretty_border) == Str.join_with(
 	[
 		"╭────────────────────────────────────────────╮",

--- a/package/PieceTable.roc
+++ b/package/PieceTable.roc
@@ -176,10 +176,10 @@ to_list_help : PieceTable(a), List(a) -> List(a)
 to_list_help = |{ original, added, table }, acc|
 	match table {
 		[] => acc
-		[PieceTable.Entry.Add(span)] => acc.concat(List.sublist(added, span))
-		[PieceTable.Entry.Original(span)] => acc.concat(List.sublist(original, span))
-		[PieceTable.Entry.Add(span), .. as rest] => to_list_help({ original, added, table: rest }, acc.concat(List.sublist(added, span)))
-		[PieceTable.Entry.Original(span), .. as rest] => to_list_help({ original, added, table: rest }, acc.concat(List.sublist(original, span)))
+		[PieceTable.Entry.Add(span)] => acc.concat(added.sublist(span))
+		[PieceTable.Entry.Original(span)] => acc.concat(original.sublist(span))
+		[PieceTable.Entry.Add(span), .. as rest] => to_list_help({ original, added, table: rest }, acc.concat(added.sublist(span)))
+		[PieceTable.Entry.Original(span), .. as rest] => to_list_help({ original, added, table: rest }, acc.concat(original.sublist(span)))
 	}
 
 test_original : List(U8)
@@ -203,107 +203,107 @@ test_table = {
 table_to_str : PieceTable(U8) -> Try(Str, _)
 table_to_str = |table| Str.from_utf8(PieceTable.to_list(table))
 
-# should fuse buffers to get content
+## Fusing buffers returns the visible content.
 expect PieceTable.to_list(test_table) == Str.to_utf8("Lorem ipsum dolor sit amet")
 
-# insert in the middle of a Add span
+## Inserting in the middle of an added span preserves both sides.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 5 }))
-	actual == Ok("Loremfoo ipsum dolor sit amet")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 5 }))?
+	actual == "Loremfoo ipsum dolor sit amet"
 }
 
-# insert at the start of a Add span
+## Inserting at the start of an added span prepends the new bytes.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 0 }))
-	actual == Ok("fooLorem ipsum dolor sit amet")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 0 }))?
+	actual == "fooLorem ipsum dolor sit amet"
 }
 
-# insert at the start of a Original span
+## Inserting at the start of an original span keeps the original bytes after the insert.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 6 }))
-	actual == Ok("Lorem fooipsum dolor sit amet")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 6 }))?
+	actual == "Lorem fooipsum dolor sit amet"
 }
 
-# insert in the middle of a Original span
+## Inserting in the middle of an original span splits that span.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 8 }))
-	actual == Ok("Lorem ipfoosum dolor sit amet")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 8 }))?
+	actual == "Lorem ipfoosum dolor sit amet"
 }
 
-# insert at start of text
+## Inserting at the start of text prepends the new bytes.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 0 }))
-	actual == Ok("fooLorem ipsum dolor sit amet")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: 0 }))?
+	actual == "fooLorem ipsum dolor sit amet"
 }
 
-# insert at end of text
+## Inserting at the end of text appends the new bytes.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: PieceTable.length(test_table.table) }))
-	actual == Ok("Lorem ipsum dolor sit ametfoo")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['f', 'o', 'o'], index: PieceTable.length(test_table.table) }))?
+	actual == "Lorem ipsum dolor sit ametfoo"
 }
 
-# insert nothing does nothing
+## Inserting an empty list leaves the text unchanged.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: [], index: 0 }))
-	actual == Ok("Lorem ipsum dolor sit amet")
+	actual = table_to_str(PieceTable.insert(test_table, { values: [], index: 0 }))?
+	actual == "Lorem ipsum dolor sit amet"
 }
 
-# insert at a range larger than current buffer
+## Inserting past the current buffer appends at the end.
 expect {
-	actual = table_to_str(PieceTable.insert(test_table, { values: ['X'], index: 999 }))
-	actual == Ok("Lorem ipsum dolor sit ametX")
+	actual = table_to_str(PieceTable.insert(test_table, { values: ['X'], index: 999 }))?
+	actual == "Lorem ipsum dolor sit ametX"
 }
 
-# delete at start of text
+## Deleting at the start of text removes the first byte.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 0 }))
-	actual == Ok("orem ipsum dolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 0 }))?
+	actual == "orem ipsum dolor sit amet"
 }
 
-# delete at end of text, note the index starts from zero
+## Deleting at the final zero-based index removes the last byte.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: PieceTable.length(test_table.table) - 1 }))
-	actual == Ok("Lorem ipsum dolor sit ame")
+	actual = table_to_str(PieceTable.delete(test_table, { index: PieceTable.length(test_table.table) - 1 }))?
+	actual == "Lorem ipsum dolor sit ame"
 }
 
-# delete at the end of an Add span
+## Deleting at the end of an added span joins the neighboring text.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 5 }))
-	actual == Ok("Loremipsum dolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 5 }))?
+	actual == "Loremipsum dolor sit amet"
 }
 
-# delete at the start of a Add span
+## Deleting at the start of an added span removes its first byte.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 11 }))
-	actual == Ok("Lorem ipsumdolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 11 }))?
+	actual == "Lorem ipsumdolor sit amet"
 }
 
-# delete in the middle of an Add span
+## Deleting in the middle of an added span splits that span.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 13 }))
-	actual == Ok("Lorem ipsum dlor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 13 }))?
+	actual == "Lorem ipsum dlor sit amet"
 }
 
-# delete at the start of a Original span
+## Deleting at the start of an original span removes its first byte.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 6 }))
-	actual == Ok("Lorem psum dolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 6 }))?
+	actual == "Lorem psum dolor sit amet"
 }
 
-# delete at the end of a Original span
+## Deleting at the end of an original span removes its final byte.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 10 }))
-	actual == Ok("Lorem ipsu dolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 10 }))?
+	actual == "Lorem ipsu dolor sit amet"
 }
 
-# delete in the middle of a Original span
+## Deleting in the middle of an original span splits that span.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 8 }))
-	actual == Ok("Lorem ipum dolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 8 }))?
+	actual == "Lorem ipum dolor sit amet"
 }
 
-# delete out of range, does nothing
+## Deleting out of range leaves the text unchanged.
 expect {
-	actual = table_to_str(PieceTable.delete(test_table, { index: 9999 }))
-	actual == Ok("Lorem ipsum dolor sit amet")
+	actual = table_to_str(PieceTable.delete(test_table, { index: 9999 }))?
+	actual == "Lorem ipsum dolor sit amet"
 }

--- a/package/Rgb.roc
+++ b/package/Rgb.roc
@@ -19,7 +19,14 @@ Rgb := (U8, U8, U8).{
 clamp : U32, U32, U32 -> U32
 clamp = |min_value, max_value, value| value.min(max_value).max(min_value)
 
+## Red hex values decode to red RGB channels.
 expect Rgb.from_hex(0xFF0000) == (255, 0, 0)
+
+## Green hex values decode to green RGB channels.
 expect Rgb.from_hex(0x00FF00) == (0, 255, 0)
+
+## Blue hex values decode to blue RGB channels.
 expect Rgb.from_hex(0x0000FF) == (0, 0, 255)
+
+## Out-of-range hex values clamp to white.
 expect Rgb.from_hex(0xFFFFFFFF) == (255, 255, 255)

--- a/package/Spacing.roc
+++ b/package/Spacing.roc
@@ -26,7 +26,14 @@ Spacing := [Padding(Side, U64)].{
 	}
 }
 
+## Top padding prepends newlines.
 expect Spacing.apply(Padding(Top, 3))("Hello") == "\n\n\nHello"
+
+## Right padding appends spaces.
 expect Spacing.apply(Padding(Right, 2))("Hello") == "Hello  "
+
+## Bottom padding appends newlines.
 expect Spacing.apply(Padding(Bottom, 3))("Hello") == "Hello\n\n\n"
+
+## Left padding prepends spaces.
 expect Spacing.apply(Padding(Left, 2))("Hello") == "  Hello"

--- a/package/Utils.roc
+++ b/package/Utils.roc
@@ -11,7 +11,7 @@ Utils := [].{
 
 	manhattan_distance : List(I64), List(I64) -> I64
 	manhattan_distance = |point1, point2| {
-		List.map2(point1, point2, |a, b| (a - b).abs())
+		point1.map2(point2, |a, b| (a - b).abs())
 			.fold(0, |acc, value| acc + value)
 	}
 
@@ -68,13 +68,34 @@ Utils := [].{
 	}
 }
 
+## Manhattan distance sums absolute coordinate differences.
 expect Utils.manhattan_distance([1, 2, 3], [4, 6, 8]) == 12
+
+## Mean averages non-empty lists.
 expect Utils.mean([6, 7]) == 6.5
+
+## Mean returns zero at the empty-list boundary.
 expect Utils.mean([]) == 0
+
+## Variance averages squared differences from the mean.
 expect Utils.variance([10, 12, 23, 23, 16, 23, 21, 16]) == 24
+
+## Standard deviation is the square root of variance.
 expect (Utils.standard_deviation([10, 12, 23, 23, 16, 23, 21, 16]) - 4.8989794855664).abs() < 0.000001
-expect Utils.median([9, 11, 8, 63, 5, 13, 10]) == Ok(10)
-expect Utils.median([6, 7]) == Ok(6.5)
+
+## Median returns the middle value for odd-length lists.
+expect {
+	actual = Utils.median([9, 11, 8, 63, 5, 13, 10])?
+	actual == 10
+}
+
+## Median averages the two middle values for even-length lists.
+expect {
+	actual = Utils.median([6, 7])?
+	actual == 6.5
+}
+
+## Median reports empty input explicitly.
 expect Utils.median([]) == Err(Empty)
 
 sqrt : F64 -> F64


### PR DESCRIPTION
Summary: update example platform bundle to roc-platform-template-zig 1.0.0; propagate fallible stdout effects and add main! annotations; apply Roc style-guide cleanup to expects and receiver-style calls. Tests: ci/all_tests.sh