### PR TITLE
Update examples for roc-ansi 0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,40 @@ jobs:
         with:
           version: nightly-new-compiler
 
+      - name: Download release metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: release-metadata
+          path: .release
+
+      - name: Update example package URLs
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
+        run: |
+          bundle_url="$(python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          bundles = json.loads(Path(".release/release-bundles.json").read_text(encoding="utf-8"))
+          if len(bundles) != 1:
+              raise SystemExit(f"expected exactly one release bundle, found {len(bundles)}")
+
+          artifact_file = bundles[0]["artifact_file"]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          version = os.environ["RELEASE_VERSION"]
+          print(f"https://github.com/{repo}/releases/download/{version}/{artifact_file}")
+          PY
+          )"
+          python3 scripts/update_example_urls.py --bundle-url "$bundle_url"
+
+      - name: Validate updated examples
+        run: |
+          for example in examples/*.roc; do
+            roc check "$example" --no-cache
+          done
+          roc test examples/tests.roc --no-cache
+
       - name: Snapshot existing docs
         uses: roc-lang/release-package/actions/docs-snapshot@e28a90a2ddeaa78a0da9ee91cc3e2d63fa770404
         with:
@@ -212,15 +246,15 @@ jobs:
           docs_root: www
           docs_version: ${{ needs.build.outputs.docs_version }}
 
-      - name: Commit docs
+      - name: Commit docs and examples
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add www
-          if git diff --cached --quiet -- www; then
-            echo "Docs did not change; skipping docs commit."
+          git add examples www
+          if git diff --cached --quiet -- examples www; then
+            echo "Docs and examples did not change; skipping release follow-up commit."
           else
-            git commit -m "Update docs for ${{ needs.build.outputs.release_version }}"
+            git commit -m "Update docs and examples for ${{ needs.build.outputs.release_version }}"
             git push origin "HEAD:${{ github.ref_name }}"
           fi
 

--- a/examples/animals.roc
+++ b/examples/animals.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
+	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.10.0/BFo7r3Lx4fuCj9ZoKagjcrkps2ceF8c1rmou1NCSos8B.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/colors.roc
+++ b/examples/colors.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
+	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.10.0/BFo7r3Lx4fuCj9ZoKagjcrkps2ceF8c1rmou1NCSos8B.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/styles.roc
+++ b/examples/styles.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
+	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.10.0/BFo7r3Lx4fuCj9ZoKagjcrkps2ceF8c1rmou1NCSos8B.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/tests.roc
+++ b/examples/tests.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
+	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.10.0/BFo7r3Lx4fuCj9ZoKagjcrkps2ceF8c1rmou1NCSos8B.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/text-editor.roc
+++ b/examples/text-editor.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
+	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.10.0/BFo7r3Lx4fuCj9ZoKagjcrkps2ceF8c1rmou1NCSos8B.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/tui-menu.roc
+++ b/examples/tui-menu.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.9.0/C2RG1B9Caohfb8dfqrKu3Wu9TDQNq4zfixxAvLnMFVEL.tar.zst",
+	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.10.0/BFo7r3Lx4fuCj9ZoKagjcrkps2ceF8c1rmou1NCSos8B.tar.zst",
 }
 
 import pf.Stdout

--- a/scripts/update_example_urls.py
+++ b/scripts/update_example_urls.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_DEPENDENCY_RE = re.compile(r'(?m)^(\s*ansi:\s*)"[^"]+"')
+
+
+def update_examples(examples_dir: Path, bundle_url: str) -> list[Path]:
+    examples = sorted(examples_dir.glob("*.roc"))
+    if not examples:
+        raise SystemExit(f"No Roc examples found in {examples_dir}")
+
+    updated: list[Path] = []
+    for example in examples:
+        source = example.read_text(encoding="utf-8")
+        rewritten, count = PACKAGE_DEPENDENCY_RE.subn(
+            lambda match: f'{match.group(1)}"{bundle_url}"',
+            source,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit(f"{example} does not declare the expected ansi package dependency")
+        if rewritten != source:
+            example.write_text(rewritten, encoding="utf-8")
+            updated.append(example)
+
+    return updated
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundle-url", required=True)
+    parser.add_argument("--examples-dir", type=Path, default=ROOT / "examples")
+    args = parser.parse_args()
+
+    updated = update_examples(args.examples_dir, args.bundle_url)
+    if updated:
+        print("Updated example URLs:")
+        for path in updated:
+            print(f"- {display_path(path)}")
+    else:
+        print("Example URLs are already up to date.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- update checked-in examples to depend on the published `roc-ansi` 0.10.0 bundle
- add a release follow-up step that rewrites example URLs to the newly published bundle URL
- validate updated examples before committing docs/examples back to the release branch

## Verification

- `python3 scripts/update_example_urls.py --bundle-url https://example.com/test-bundle.tar.zst --examples-dir /tmp/roc-ansi-example-update-test/examples`
- `python3 -m py_compile scripts/update_example_urls.py ci/test_bundle_examples.py`
- `ROC=/tmp/roc-nightly-2f217bc/roc_nightly-macos_apple_silicon-2026-07-09-2f217bc/roc ci/all_tests.sh`
- `git diff --check origin/main..HEAD`