### PR TITLE
Update value methods for latest Roc compiler

### DIFF
--- a/examples/tests.roc
+++ b/examples/tests.roc
@@ -5,9 +5,14 @@ app [main!] {
 
 import pf.Stdout
 import ansi.ANSI
+import ansi.C16
 import ansi.C256
+import ansi.Color
+import ansi.Control
 import ansi.PieceTable
 import ansi.Rgb
+import ansi.Spacing
+import ansi.Style
 
 main! : List(Str) => Try({}, [Exit(I32), StdoutErr(Str), ..])
 main! = |_args| {
@@ -23,6 +28,24 @@ expect Rgb.from_hex(0x008080) == (0, 128, 128)
 
 ## Arrow key input renders a readable description.
 expect ANSI.input_to_str(ANSI.Input.Arrow(ANSI.Arrow.Up)) == "Arrow Up"
+
+## Parsed input values support derived equality and hashing.
+expect {
+	input = ANSI.Input.Arrow(ANSI.Arrow.Up)
+
+	input == ANSI.Input.Arrow(ANSI.Arrow.Up) and Set.contains(Set.single(input), input)
+}
+
+## Terminal values support derived equality and hashing through nested nominal types.
+expect {
+	red = Color.Color.C16(C16.C16.Standard(C16.Name.Red))
+	style = Style.Style.Foreground(red)
+	control = Control.Control.Style(style)
+	escape = ANSI.Escape.Control(control)
+	spacing = Spacing.padding(Spacing.Side.Left, 2)
+
+	Set.contains(Set.single(escape), escape) and spacing == Spacing.padding(Spacing.Side.Left, 2) and Set.contains(Set.single(spacing), spacing)
+}
 
 base_table : PieceTable.PieceTable(U8)
 base_table = {

--- a/package/ANSI.roc
+++ b/package/ANSI.roc
@@ -7,7 +7,10 @@ ANSI := [].{
 	Escape := [
 		Reset,
 		Control(ControlPkg.Control),
-	]
+	].{
+		is_eq : _
+		to_hash : _
+	}
 
 	to_str : Escape -> Str
 	to_str = |escape|
@@ -64,13 +67,31 @@ ANSI := [].{
 		VerticalBar,
 		CurlyCloseBrace,
 		Tilde,
-	]
+	].{
+		is_eq : _
+		to_hash : _
+	}
 
-	Ctrl := [Space, A, B, C, D, E, F, G, H, I, J, K, L, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, BackSlash, SquareCloseBracket, Caret, Underscore]
-	Action := [Escape, Enter, Space, Delete]
-	Arrow := [Up, Down, Left, Right]
-	Number := [N0, N1, N2, N3, N4, N5, N6, N7, N8, N9]
-	Letter := [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]
+	Ctrl := [Space, A, B, C, D, E, F, G, H, I, J, K, L, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, BackSlash, SquareCloseBracket, Caret, Underscore].{
+		is_eq : _
+		to_hash : _
+	}
+	Action := [Escape, Enter, Space, Delete].{
+		is_eq : _
+		to_hash : _
+	}
+	Arrow := [Up, Down, Left, Right].{
+		is_eq : _
+		to_hash : _
+	}
+	Number := [N0, N1, N2, N3, N4, N5, N6, N7, N8, N9].{
+		is_eq : _
+		to_hash : _
+	}
+	Letter := [A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z].{
+		is_eq : _
+		to_hash : _
+	}
 
 	Input := [
 		Ctrl(Ctrl),
@@ -81,7 +102,10 @@ ANSI := [].{
 		Upper(Letter),
 		Lower(Letter),
 		Unsupported(List(U8)),
-	]
+	].{
+		is_eq : _
+		to_hash : _
+	}
 
 	parse_raw_stdin : List(U8) -> Input
 	parse_raw_stdin = |bytes|
@@ -634,9 +658,7 @@ join_all_pixels = |rows| {
 }
 
 join_pixel_row :
-	{ char : Str, fg : ColorPkg.Color, bg : ColorPkg.Color, lines : List(Str), styles : List(StylePkg.Style) },
-	List(ANSI.Pixel),
-	U64 -> { char : Str, fg : ColorPkg.Color, bg : ColorPkg.Color, lines : List(Str), styles : List(StylePkg.Style) }
+	{ char : Str, fg : ColorPkg.Color, bg : ColorPkg.Color, lines : List(Str), styles : List(StylePkg.Style) }, List(ANSI.Pixel), U64 -> { char : Str, fg : ColorPkg.Color, bg : ColorPkg.Color, lines : List(Str), styles : List(StylePkg.Style) }
 join_pixel_row = |{ char, fg, bg, lines, styles }, pixel_row, row| {
 	folded = {
 		pixel_row.fold(

--- a/package/C16.roc
+++ b/package/C16.roc
@@ -4,7 +4,13 @@ import C256
 ## These colors can be customized, leading to variations across different terminals.
 ## Therefore, if your use case requires a consistent color palette, it's recommended to avoid using them.
 C16 := [Standard(Name), Bright(Name)].{
-	Name := [Black, Red, Green, Yellow, Blue, Magenta, Cyan, White]
+	is_eq : _
+	to_hash : _
+
+	Name := [Black, Red, Green, Yellow, Blue, Magenta, Cyan, White].{
+		is_eq : _
+		to_hash : _
+	}
 
 	name_to_code : Name -> U8
 	name_to_code = |name|

--- a/package/Color.roc
+++ b/package/Color.roc
@@ -13,6 +13,9 @@ Color := [
 	Standard(C16.Name),
 	Bright(C16.Name),
 ].{
+	is_eq : _
+	to_hash : _
+
 	to_code : Color, U8 -> List(U8)
 	to_code = |color, offset|
 		match color {

--- a/package/Control.roc
+++ b/package/Control.roc
@@ -32,6 +32,9 @@ Control := [
 	Scroll([Up, Down], U16),
 	Style(Style.Style),
 ].{
+	is_eq : _
+	to_hash : _
+
 	to_code : Control -> Str
 	to_code = |control|
 		match control {

--- a/package/Layout.roc
+++ b/package/Layout.roc
@@ -272,15 +272,7 @@ f64_to_u64 = |value| {
 }
 
 draw_grid_rows :
-	List(List(Str)),
-	List(U64),
-	Layout.LineFill(Str),
-	Str,
-	Str,
-	Layout.RowSpacing,
-	(U64, U64),
-	U64,
-	List(Str) -> List(Str)
+	List(List(Str)), List(U64), Layout.LineFill(Str), Str, Str, Layout.RowSpacing, (U64, U64), U64, List(Str) -> List(Str)
 draw_grid_rows = |grid, sizes, border, sep_line, padding_line, row_spacing, py, index, out| {
 	match grid {
 		[] => out

--- a/package/PieceTable.roc
+++ b/package/PieceTable.roc
@@ -70,27 +70,21 @@ insert_help = |input, { index, span }, out|
 			len_after = current.len - len_before
 
 			if len_before > 0 and len_after > 0 {
-				out.concat(
-					[
-						PieceTable.Entry.Add({ start: current.start, len: len_before }),
-						span,
-						PieceTable.Entry.Add({ start: current.start + len_before, len: len_after }),
-					],
-				).concat(rest)
+				out.concat([
+					PieceTable.Entry.Add({ start: current.start, len: len_before }),
+					span,
+					PieceTable.Entry.Add({ start: current.start + len_before, len: len_after }),
+				]).concat(rest)
 			} else if len_before > 0 {
-				out.concat(
-					[
-						PieceTable.Entry.Add({ start: current.start, len: len_before }),
-						span,
-					],
-				).concat(rest)
+				out.concat([
+					PieceTable.Entry.Add({ start: current.start, len: len_before }),
+					span,
+				]).concat(rest)
 			} else {
-				out.concat(
-					[
-						span,
-						PieceTable.Entry.Add({ start: current.start + len_before, len: len_after }),
-					],
-				).concat(rest)
+				out.concat([
+					span,
+					PieceTable.Entry.Add({ start: current.start + len_before, len: len_after }),
+				]).concat(rest)
 			}
 		}
 
@@ -99,27 +93,21 @@ insert_help = |input, { index, span }, out|
 			len_after = current.len - len_before
 
 			if len_before > 0 and len_after > 0 {
-				out.concat(
-					[
-						PieceTable.Entry.Original({ start: current.start, len: len_before }),
-						span,
-						PieceTable.Entry.Original({ start: current.start + len_before, len: len_after }),
-					],
-				).concat(rest)
+				out.concat([
+					PieceTable.Entry.Original({ start: current.start, len: len_before }),
+					span,
+					PieceTable.Entry.Original({ start: current.start + len_before, len: len_after }),
+				]).concat(rest)
 			} else if len_before > 0 {
-				out.concat(
-					[
-						PieceTable.Entry.Original({ start: current.start, len: len_before }),
-						span,
-					],
-				).concat(rest)
+				out.concat([
+					PieceTable.Entry.Original({ start: current.start, len: len_before }),
+					span,
+				]).concat(rest)
 			} else {
-				out.concat(
-					[
-						span,
-						PieceTable.Entry.Original({ start: current.start + len_before, len: len_after }),
-					],
-				).concat(rest)
+				out.concat([
+					span,
+					PieceTable.Entry.Original({ start: current.start + len_before, len: len_after }),
+				]).concat(rest)
 			}
 		}
 	}
@@ -144,12 +132,10 @@ delete_from_add = |span, rest, index, out| {
 	} else if is_end_of_span {
 		out.concat([PieceTable.Entry.Add({ start: span.start, len: span.len - 1 })]).concat(rest)
 	} else {
-		out.concat(
-			[
-				PieceTable.Entry.Add({ start: span.start, len: index }),
-				PieceTable.Entry.Add({ start: span.start + index + 1, len: span.len - index - 1 }),
-			],
-		).concat(rest)
+		out.concat([
+			PieceTable.Entry.Add({ start: span.start, len: index }),
+			PieceTable.Entry.Add({ start: span.start + index + 1, len: span.len - index - 1 }),
+		]).concat(rest)
 	}
 }
 
@@ -163,12 +149,10 @@ delete_from_original = |span, rest, index, out| {
 	} else if is_end_of_span {
 		out.concat([PieceTable.Entry.Original({ start: span.start, len: span.len - 1 })]).concat(rest)
 	} else {
-		out.concat(
-			[
-				PieceTable.Entry.Original({ start: span.start, len: index }),
-				PieceTable.Entry.Original({ start: span.start + index + 1, len: span.len - index - 1 }),
-			],
-		).concat(rest)
+		out.concat([
+			PieceTable.Entry.Original({ start: span.start, len: index }),
+			PieceTable.Entry.Original({ start: span.start + index + 1, len: span.len - index - 1 }),
+		]).concat(rest)
 	}
 }
 

--- a/package/Spacing.roc
+++ b/package/Spacing.roc
@@ -1,6 +1,12 @@
 ## Helpers for horizontal and vertical whitespace.
 Spacing := [Padding(Side, U64)].{
-	Side := [Top, Right, Bottom, Left]
+	is_eq : _
+	to_hash : _
+
+	Side := [Top, Right, Bottom, Left].{
+		is_eq : _
+		to_hash : _
+	}
 
 	xw : Str
 	xw = " "

--- a/package/Style.roc
+++ b/package/Style.roc
@@ -15,6 +15,9 @@ Style := [
 	Foreground(Color.Color),
 	Background(Color.Color),
 ].{
+	is_eq : _
+	to_hash : _
+
 	to_code : Style -> List(U8)
 	to_code = |style|
 		match style {


### PR DESCRIPTION
## Summary

- opt terminal value types into compiler-derived is_eq and to_hash methods
- cover nested nominal values used by colors, styles, controls, escape sequences, parsed input, and spacing
- add package-consumer coverage for equality and Set membership
- apply formatting required by the latest Roc formatter

## API choices

Equality and hashing are useful for comparing terminal state, testing parsed input, and using these immutable values as Dict or Set keys. The methods are derived together so their semantics remain consistent.

This intentionally does not derive parser_for or encoder_for because roc-ansi does not currently promise a serialization format. It also leaves PieceTable without structural equality because that would compare edit history rather than rendered document content. map and map! do not fit these non-container types.

Reference: https://github.com/roc-lang/roc/blob/main/docs/langref/static-dispatch.md#compiler-derived-methods

## Testing

- bash ci/all_tests.sh
- Roc compiler version debug-2988994a
- 52 package tests pass
- package docs generate
- bundled package checks, tests, runs, and builds all examples