### PR TITLE
Warn on release bump check failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,9 @@ jobs:
         with:
           release_version: ${{ steps.validate.outputs.release_version }}
           dry_run: ${{ github.event_name != 'workflow_dispatch' }}
-          bump_check: require
+          # Nightly compilers can make previous release bundles uncompilable.
+          # Restore `require` once Roc 0.1.0 provides a stable compatibility baseline.
+          bump_check: warn
           bump_entrypoint: package/main.roc
           previous_url: ${{ steps.previous.outputs.previous_url }}
 


### PR DESCRIPTION
## Summary

- change the release bump check from require to warn while roc-ansi tracks nightly Roc compilers
- retain roc bump output for diagnostics and release notes without blocking an otherwise valid release
- document restoring strict enforcement once Roc 0.1.0 provides a stable compatibility baseline

## Failure investigated

The 0.12.0 release run failed before bundling because roc bump tried to compile the 0.11.0 bundle with the latest compiler. That previous bundle predates compiler-derived is_eq methods, so it cannot compile and its API cannot be compared.

Failed run: https://github.com/lukewilliamboswell/roc-ansi/actions/runs/29895818266

The pinned release-package action treats warn mode as non-blocking while still writing and printing the complete bump failure.

## Verification

- confirmed warn is an accepted run-bump-check input in the pinned action
- confirmed warn returns success after preserving non-zero roc bump output
- git diff --check