### PR TITLE
Omit failed bump output from release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,22 @@ jobs:
           bump_entrypoint: package/main.roc
           previous_url: ${{ steps.previous.outputs.previous_url }}
 
+      - name: Classify bump output for release notes
+        run: |
+          bump_output=".release/bump-output.txt"
+          if [[ ! -s "$bump_output" ]]; then
+            exit 0
+          fi
+          if grep -Eq '^(Comparing |roc bump check skipped|No previous release bundle found;)' "$bump_output"; then
+            exit 0
+          fi
+          {
+            echo "roc bump check skipped because no API comparison was produced."
+            echo
+            cat "$bump_output"
+          } > "$bump_output.tmp"
+          mv "$bump_output.tmp" "$bump_output"
+
       - name: Bundle package
         run: ./scripts/bundle.sh --output-dir dist
 


### PR DESCRIPTION
## Summary

- distinguish valid roc bump API comparisons from warned compiler failures
- preserve failed bump diagnostics in the metadata artifact
- mark non-comparison output as skipped so release notes do not render ANSI compiler errors as Roc API changes

## Context

The 0.12.0 release used bump_check warn because 0.11.0 cannot compile with the current nightly compiler. The release-package action preserved that failure output, and make-release-notes treated it as a meaningful API diff.

The published 0.12.0 notes have already been repaired manually.

## Verification

- tested classification against the actual 0.12.0 release-metadata artifact
- confirmed failure diagnostics are preserved after the recognized skip prefix
- valid output beginning with Comparing remains eligible for release notes
- git diff --check