### PR TITLE
Update for latest Roc

### DIFF
--- a/package/Rgb.roc
+++ b/package/Rgb.roc
@@ -9,7 +9,7 @@ Rgb := (U8, U8, U8).{
 				_ => 0
 			}
 
-			U32.to_u8_wrap(U32.bitwise_and(U32.shift_right_by(u24, shift), 0xFF))
+			U32.to_u8_wrap(U32.bitwise_and(U32.shr_zf_wrap(u24, shift), 0xFF))
 		}
 
 		(c(0), c(1), c(2))


### PR DESCRIPTION
## Summary

- replace the removed `U32.shift_right_by` API with `U32.shr_zf_wrap`
- preserve unsigned zero-fill shift behavior in RGB hex decoding

## Testing

- `./ci/all_tests.sh`
- Roc compiler version `release-fast-f4b3c607`