### PR TITLE
Simplify the Pages landing page around an example grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Generate the landing page with fresh main-branch API docs, then serve the isolat
 
 The preview chooses a free local port and opens it automatically; its landing page links to freshly generated `/main/` API docs. Pass `--no-open` to avoid opening a browser, `--no-serve` to only assemble the preview, or `--port 8000` to choose a fixed port. Set `ROC=/path/to/roc` if `roc` is not on your `PATH`.
 
-The preview also includes rendered terminal captures and highlighted source for each runnable example at `/examples/`. The site vendors the Tree-sitter Roc grammar and web runtime for client-side highlighting; see [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) for license details.
+The landing page shows a terminal capture for each runnable example, linking to its source on GitHub. The site vendors the Tree-sitter Roc grammar and web runtime for client-side highlighting; see [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) for license details.

--- a/scripts/enhance_docs_site.py
+++ b/scripts/enhance_docs_site.py
@@ -17,8 +17,7 @@ DOCS_INTRO = """
         <p>Typed helpers for ANSI terminal control sequences in Roc: colors, text
         styles, cursor and screen control, input parsing, and simple layouts.</p>
         <p>Pick a module from the sidebar, or head back to the
-        <a href="{root}">roc-ansi site</a> for
-        <a href="{root}examples/">rendered examples</a>.</p>
+        <a href="{root}">roc-ansi site</a> for examples.</p>
 """
 
 

--- a/scripts/generate_example_pages.py
+++ b/scripts/generate_example_pages.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate site pages that pair terminal captures with their Roc source."""
+"""Copy example terminal captures into the site and build the landing-page grid."""
 from __future__ import annotations
 import argparse
 import html
@@ -7,60 +7,46 @@ import shutil
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-REPO = "https://github.com/lukewilliamboswell/roc-ansi"
+SOURCE_URL = "https://github.com/lukewilliamboswell/roc-ansi/blob/main/examples"
+PLACEHOLDER = "<!--EXAMPLES-->"
 EXAMPLES = {
-    "animals": ("Animals", "A short sentence composed from independently colored terminal fragments."),
-    "colors": ("Colors", "ANSI 16-color, 256-color, and RGB foreground and background combinations."),
-    "styles": ("Styles", "Bold, faint, italic, strike-through, underline, invert, and combined styles."),
-    "tui-menu": ("TUI menu", "A compact interactive-menu treatment using color and emphasis."),
-    "text-editor": ("Text editor", "A terminal text-editing example backed by the package's piece table."),
+    "animals": "Animals",
+    "colors": "Colors",
+    "styles": "Styles",
+    "tui-menu": "TUI menu",
+    "text-editor": "Text editor",
 }
-
-def document(title: str, body: str, *, root: str = "../") -> str:
-    return f"""<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>{html.escape(title)} · roc-ansi</title>
-<link rel="icon" type="image/svg+xml" href="{root}favicon.svg">
-<link rel="stylesheet" href="{root}vendor/simple-css/simple.min.css"><link rel="stylesheet" href="{root}site.css"><link rel="stylesheet" href="{root}roc-highlight.css">
-</head><body><header><nav>
-<a class="brand" href="{root}">roc-ansi</a>
-<a href="{root}main/">API docs</a>
-<a href="{root}examples/">Examples</a>
-<a href="{REPO}">GitHub</a>
-<a href="{REPO}/releases">Releases</a>
-</nav></header>
-<main>{body}</main><footer>roc-ansi is open source under the UPL-1.0 license.</footer>
-<script type="module" src="{root}roc-highlight.js"></script></body></html>
-"""
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("site", type=Path)
     site = parser.parse_args().site.resolve()
-    output = site / "examples"
-    assets = output / "assets"
+    assets = site / "examples"
     assets.mkdir(parents=True, exist_ok=True)
+
     cards: list[str] = []
-    for slug, (title, description) in EXAMPLES.items():
+    for slug, title in EXAMPLES.items():
         source_path = ROOT / "examples" / f"{slug}.roc"
-        media_path = ROOT / "examples" / f"{slug}.gif"
-        if not media_path.is_file():
-            media_path = ROOT / "examples" / f"{slug}.png"
+        media_path = ROOT / "examples" / f"{slug}.png"
         if not source_path.is_file() or not media_path.is_file():
             raise SystemExit(f"Missing source or terminal capture for {slug}")
         shutil.copy2(media_path, assets / media_path.name)
-        source = html.escape(source_path.read_text(encoding="utf-8"))
-        body = f'<p><a href="../">← All examples</a></p><h1>{html.escape(title)}</h1><p>{html.escape(description)}</p>'
-        body += f'<figure class="terminal-capture"><img src="../assets/{media_path.name}" alt="{html.escape(title)} rendered in a terminal"><figcaption>Terminal output</figcaption></figure>'
-        body += f'<h2>Source</h2><pre><code class="language-roc">{source}</code></pre>'
-        page_dir = output / slug
-        page_dir.mkdir(exist_ok=True)
-        (page_dir / "index.html").write_text(document(title, body, root="../../"), encoding="utf-8")
-        cards.append(f'<article><a href="./{slug}/"><img src="./assets/{media_path.name}" alt="{html.escape(title)} terminal output"></a><h2><a href="./{slug}/">{html.escape(title)}</a></h2><p>{html.escape(description)}</p></article>')
-    gallery = '<h1>Examples</h1><p>See each program rendered in a terminal alongside its complete Roc source.</p><div class="example-grid">' + "".join(cards) + "</div>"
-    (output / "index.html").write_text(document("Examples", gallery), encoding="utf-8")
-    print(f"Generated {len(EXAMPLES)} example pages in {output}")
+        label = html.escape(title)
+        cards.append(
+            f'<a class="example" href="{SOURCE_URL}/{slug}.roc">'
+            f'<img src="./examples/{media_path.name}" alt="{label} rendered in a terminal" loading="lazy">'
+            f"<span>{label}</span></a>"
+        )
+
+    index = site / "index.html"
+    document = index.read_text(encoding="utf-8")
+    if PLACEHOLDER not in document:
+        raise SystemExit(f"{index} is missing {PLACEHOLDER}")
+    grid = '<div class="example-grid">' + "".join(cards) + "</div>"
+    index.write_text(document.replace(PLACEHOLDER, grid, 1), encoding="utf-8")
+    print(f"Added {len(EXAMPLES)} examples to the landing page")
+
 
 if __name__ == "__main__":
     main()

--- a/www/index.html
+++ b/www/index.html
@@ -4,36 +4,30 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Typed helpers for ANSI terminal control sequences in Roc.">
-  <title>roc-ansi · terminal styling for Roc</title>
+  <title>roc-ansi</title>
   <link rel="icon" type="image/svg+xml" href="./favicon.svg">
   <link rel="stylesheet" href="./vendor/simple-css/simple.min.css">
   <link rel="stylesheet" href="./site.css">
   <link rel="stylesheet" href="./roc-highlight.css">
 </head>
 <body>
-  <header class="hero">
+  <header>
     <nav>
       <a class="brand" href="./">roc-ansi</a>
       <a href="./main/">API docs</a>
-      <a href="./examples/">Examples</a>
       <a href="https://github.com/lukewilliamboswell/roc-ansi">GitHub</a>
       <a href="https://github.com/lukewilliamboswell/roc-ansi/releases">Releases</a>
     </nav>
-    <h1>Colorful terminal interfaces, in Roc.</h1>
-    <p>Compose ANSI colors, styles, cursor controls, input handling, and simple terminal layouts with typed helpers.</p>
-    <p><a class="button" href="./main/">Browse the API documentation</a> <a class="button button-secondary" href="./examples/">See the examples</a></p>
+    <p>ANSI colors, styles, cursor control, input parsing, and terminal layout for Roc.</p>
   </header>
   <main>
     <section>
-      <h2>Small, composable building blocks</h2>
-      <div class="cards">
-        <article><h3>Style text</h3><p>Apply 16-color, 256-color, or RGB foreground and background colors alongside bold, italic, underline, and other styles.</p></article>
-        <article><h3>Control the terminal</h3><p>Move the cursor, erase regions, scroll, query terminal state, and render screen-oriented layouts.</p></article>
-        <article><h3>Handle input</h3><p>Parse raw terminal bytes into typed keys, arrows, controls, symbols, and cursor positions.</p></article>
-      </div>
+      <h2>Examples</h2>
+      <p>Each screenshot links to its source on GitHub.</p>
+      <!--EXAMPLES-->
     </section>
     <section>
-      <h2>A quick taste</h2>
+      <h2>Getting started</h2>
       <pre class="snippet"><code class="language-roc">app [main!] {
 	ansi: &quot;https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.12.0/J75zfZxPJQwSG7sQJFnZHVAbJj55L3myvst2WcDWcEaZ.tar.zst&quot;,
 }
@@ -47,20 +41,12 @@ main! = |_args| {
 	echo!(greeting)
 	Ok({})
 }</code></pre>
-      <p>Add the <code>ansi</code> dependency to your app header, then import the modules you need.
-      Each <a href="https://github.com/lukewilliamboswell/roc-ansi/releases/latest">release</a> publishes the bundled package to depend on.</p>
+      <p>Add the <code>ansi</code> dependency to your app header, then import the modules you need. Every
+      <a href="https://github.com/lukewilliamboswell/roc-ansi/releases/latest">release</a> publishes a bundled package URL.</p>
     </section>
     <section>
-      <h2>Explore</h2>
-      <ul>
-        <li><a href="./main/">Main branch API docs</a>, regenerated on every deployment.</li>
-        <li><a href="./examples/">Rendered examples and source</a> for colors, styles, menus, and a text editor.</li>
-        <li><a href="https://github.com/lukewilliamboswell/roc-ansi/releases/latest">Latest release</a> and its package bundle.</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Released documentation</h2>
-      <p>API documentation is archived for each release.</p>
+      <h2>Documentation</h2>
+      <p><a href="./main/">API docs for main</a>, rebuilt on every deployment. Archived per release:</p>
       <!--VERSIONS-->
     </section>
   </main>

--- a/www/site.css
+++ b/www/site.css
@@ -1,7 +1,19 @@
-:root { --accent: #7357d8; --accent-hover: #957ce8; }
+:root { --accent: #7357d8; }
+
+/* simple.css centres a narrow reading column; the screenshot grid needs room. */
+body { grid-template-columns: 1fr min(64rem, 90%) 1fr; }
+/* simple.css lets the header span the full width; keep it on the content grid. */
+body > header > * { max-width: 64rem; margin-inline: auto; }
+body > main { padding-block: 1.5rem; }
+main > section:first-child, main > section:first-child > :first-child { margin-top: 0; }
+main > section { margin-top: 2.5rem; }
+h1 { font-size: 1.8rem; }
+h2 { font-size: 1.4rem; margin-bottom: .5rem; }
 
 /* Nav */
-header nav { margin-bottom: 0; }
+body > header { padding-block: 1rem; text-align: left; }
+body > header > p { max-width: 64rem; margin: 0 auto; }
+header nav { margin-bottom: .5rem; justify-content: flex-start; }
 header nav a.brand { font-size: 1.25rem; font-weight: 750; }
 header nav a.brand,
 header nav a.brand:visited {
@@ -14,32 +26,12 @@ header nav a.brand:visited {
 }
 header nav a.brand:hover { border: 0; color: var(--accent); }
 
-/* Only the landing page gets the tall hero band. */
-header.hero { padding-bottom: 3rem; }
-header.hero h1 { max-width: 18ch; margin: 3rem auto 1rem; font-size: clamp(2.8rem, 7vw, 5rem); letter-spacing: -.035em; }
-header.hero > p { max-width: 44rem; margin-inline: auto; }
-body > header:not(.hero) { padding-block: 1rem; }
-
-/* Buttons */
-a.button { display: inline-block; border-radius: .4rem; background: var(--accent); color: white !important; font-weight: 700; padding: .7rem 1rem; text-decoration: none; }
-a.button:hover { background: var(--accent-hover); }
-a.button-secondary { background: transparent; color: var(--accent) !important; border: 2px solid var(--accent); padding: calc(.7rem - 2px) calc(1rem - 2px); }
-a.button-secondary:hover { background: var(--accent); color: white !important; }
-
-/* Card grids */
-.cards, .example-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 1rem; }
-.cards article, .example-grid article { margin: 0; display: flex; flex-direction: column; }
-.cards article > *:last-child, .example-grid article > *:last-child { margin-bottom: 0; }
-.cards article h3 { margin-block: 0 .6rem; }
-.example-grid img { width: 100%; height: 13rem; border-radius: .35rem; background: #111; object-fit: contain; }
-.example-grid h2 { font-size: 1.3rem; margin-block: .8rem .4rem; }
-.example-grid h2 a { text-decoration: none; }
-.example-grid h2 a:hover { text-decoration: underline; }
-
-/* Example detail pages */
-.terminal-capture { margin-inline: 0; text-align: center; }
-.terminal-capture img { max-width: 100%; max-height: 38rem; border-radius: .5rem; background: #111; object-fit: contain; }
-.terminal-capture figcaption { color: var(--text-light); }
+/* Example grid: a terminal capture per example, linking to its source. */
+.example-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr)); gap: 1rem; }
+.example-grid a.example { display: block; padding: .5rem; border: 1px solid var(--border); border-radius: .5rem; text-decoration: none; color: var(--text); }
+.example-grid a.example:hover { border-color: var(--accent); }
+.example-grid img { display: block; width: 100%; height: 12rem; border-radius: .35rem; background: #111; object-fit: contain; }
+.example-grid span { display: block; padding: .5rem .25rem 0; font-weight: 600; }
 
 /* Archived documentation versions */
 .version-list { display: flex; flex-wrap: wrap; gap: .5rem; padding: 0; list-style: none; }
@@ -47,6 +39,6 @@ a.button-secondary:hover { background: var(--accent); color: white !important; }
 .version-list a { display: inline-block; border: 1px solid var(--border); border-radius: .4rem; padding: .35rem .8rem; text-decoration: none; }
 .version-list a:hover { border-color: var(--accent); }
 
-pre { max-height: 46rem; overflow-x: auto; tab-size: 4; }
+pre { overflow-x: auto; tab-size: 4; }
 /* Landing-page snippet: wrap long dependency URLs instead of scrolling sideways. */
 pre.snippet code { white-space: pre-wrap; overflow-wrap: anywhere; }


### PR DESCRIPTION
The GitHub Pages site led with a marketing hero, two call-to-action buttons, and three "building blocks" feature cards — and buried the terminal captures on a separate `/examples/` gallery behind five generated detail pages.

This leads with the examples instead. The landing page is now a compact nav, a one-line description, a grid of terminal captures linking to each example's source on GitHub, the dependency snippet, and the docs links.

## Changes

- **`www/index.html`** — dropped the hero, buttons, and feature cards. Added an `<!--EXAMPLES-->` placeholder for the grid.
- **`scripts/generate_example_pages.py`** — no longer builds the gallery or the five detail pages. It copies the captures into the site and fills the placeholder, each tile linking to `examples/<slug>.roc` on GitHub. Switched from GIF-preferred to the PNG stills, since the two GIFs opened on blank frames and read as broken thumbnails at grid size.
- **`www/site.css`** — removed the hero/button/card/detail-page rules; widened the content column to 64rem so the grid gets three columns, and tightened heading sizes and section spacing.
- **`scripts/enhance_docs_site.py`, `README.md`** — updated the two references to the removed `/examples/` page.

## Worth flagging

`/examples/` and the five per-example URLs are gone, so existing bookmarks will 404. Happy to keep them if you'd rather.

## QA

Assembled and reviewed locally with `./scripts/serve_www.py`: the grid renders and reflows to one column when narrowed, each tile links to the right source file, and `/main/` API docs still load with a working link back to the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pK8j5mXfnDUbAowmw4RRW