### PR TITLE
Trial opt-in automatic merging of validated nightly pins

### DIFF
--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,10 +7,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8`.
+The caller workflows pin shared code to `8691138c0aab4a7509e3b489e7dff7d91816264f`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/8691138c0aab4a7509e3b489e7dff7d91816264f/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
 GITHUB_TOKEN run. Keep default token permissions read-only. The updater never approves PRs and receives no protection bypass. This repository
 opts into automatic merging of validated compiler-pin PRs as the initial trial.
@@ -24,7 +24,7 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/8691138c0aab4a7509e3b489e7dff7d91816264f/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.
 
@@ -33,8 +33,8 @@ compliance or change repository settings.
 
 `auto_merge: true` in `.github/roc-nightly.json` enables the shared merge policy.
 Only a verified Actions-bot commit changing `.roc-version` on the current default
-branch can qualify. The isolated merge job rechecks both validation runs through
-the API and requests a squash merge of that exact candidate SHA.
+branch can qualify. The isolated merge job performs no repository checkout and reads its policy at
+the trusted event SHA. It rechecks both validation runs through the API and requests a squash merge of that exact candidate SHA.
 
 The active default-branch trial ruleset requires PRs, verified signatures, an
 up-to-date branch, and these GitHub Actions checks:

--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,13 +7,13 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2`.
+The caller workflows pin shared code to `f54c7aef59a7de19a5e3133a93cd1a415c1e2c60`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/f54c7aef59a7de19a5e3133a93cd1a415c1e2c60/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
-GITHUB_TOKEN run. Keep default token permissions read-only. The updater never
-approves or merges PRs and receives no protection bypass.
+GITHUB_TOKEN run. Keep default token permissions read-only. The updater never approves PRs and receives no protection bypass. This repository
+opts into automatic merging of validated compiler-pin PRs as the initial trial.
 
 `automation/roc-nightly` is reserved for the bot's pin-only commits. Put manual
 compatibility changes on a separate branch. Candidate failures require diagnosis;
@@ -24,6 +24,38 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/f54c7aef59a7de19a5e3133a93cd1a415c1e2c60/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.
+
+
+## Automatic merge trial
+
+`auto_merge: true` in `.github/roc-nightly.json` enables the shared merge policy.
+Only a verified Actions-bot commit changing `.roc-version` on the current default
+branch can qualify. The isolated merge job rechecks both validation runs through
+the API and requests a squash merge of that exact candidate SHA.
+
+The active default-branch trial ruleset requires PRs, verified signatures, an
+up-to-date branch, and these GitHub Actions checks:
+
+- `test-examples`
+- `Build release bundle`
+- `Test default bundle (ubuntu-latest)`
+
+It blocks deletion and force pushes, grants no bypass, and requires zero human
+approvals. Human review remains the project policy for source and automation
+changes; this ruleset does not technically enforce that distinction. The bot's
+pin-only eligibility is enforced by the trusted controller.
+
+Nightly validation does not publish releases or deploy docs. A bot-token merge
+also does not automatically trigger push workflows. Release publication remains
+an explicit operation.
+
+Disable merging by setting `auto_merge` to false in a PR. Disable the Update Roc
+nightly workflow in GitHub Actions for an immediate stop. On rejection or failure,
+inspect the updater run and retry manually after resolving the cause.
+
+This opts into unattended dependency updates, not automated human review. It can
+reduce OpenSSF Scorecard's Code-Review score; it does not establish or invalidate
+the passing Best Practices badge by itself. See the shared OpenSSF guidance.

--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,10 +7,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `f54c7aef59a7de19a5e3133a93cd1a415c1e2c60`.
+The caller workflows pin shared code to `b34ee7488209489ed7a1ef436606c3d9ed8913be`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/f54c7aef59a7de19a5e3133a93cd1a415c1e2c60/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/b34ee7488209489ed7a1ef436606c3d9ed8913be/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
 GITHUB_TOKEN run. Keep default token permissions read-only. The updater never approves PRs and receives no protection bypass. This repository
 opts into automatic merging of validated compiler-pin PRs as the initial trial.
@@ -24,7 +24,7 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/f54c7aef59a7de19a5e3133a93cd1a415c1e2c60/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/b34ee7488209489ed7a1ef436606c3d9ed8913be/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.
 

--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,10 +7,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `b34ee7488209489ed7a1ef436606c3d9ed8913be`.
+The caller workflows pin shared code to `42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/b34ee7488209489ed7a1ef436606c3d9ed8913be/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
 GITHUB_TOKEN run. Keep default token permissions read-only. The updater never approves PRs and receives no protection bypass. This repository
 opts into automatic merging of validated compiler-pin PRs as the initial trial.
@@ -24,7 +24,7 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/b34ee7488209489ed7a1ef436606c3d9ed8913be/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.
 

--- a/.github/roc-nightly.json
+++ b/.github/roc-nightly.json
@@ -2,5 +2,6 @@
   "workflows": [
     "tests.yaml",
     "release.yml"
-  ]
+  ],
+  "auto_merge": true
 }

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@f54c7aef59a7de19a5e3133a93cd1a415c1e2c60
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@b34ee7488209489ed7a1ef436606c3d9ed8913be

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@b34ee7488209489ed7a1ef436606c3d9ed8913be
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@f54c7aef59a7de19a5e3133a93cd1a415c1e2c60

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@8691138c0aab4a7509e3b489e7dff7d91816264f

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -15,4 +15,4 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@b34ee7488209489ed7a1ef436606c3d9ed8913be
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -15,4 +15,4 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@c6711b0f46ee57beda8e1db4f3eafcbcd9cddae2
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@f54c7aef59a7de19a5e3133a93cd1a415c1e2c60

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -15,4 +15,4 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@42b13b90ba3d40d76a671d1bbaeb31c7adaa11b8
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@8691138c0aab4a7509e3b489e7dff7d91816264f

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -15,4 +15,4 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@f54c7aef59a7de19a5e3133a93cd1a415c1e2c60
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@b34ee7488209489ed7a1ef436606c3d9ed8913be


### PR DESCRIPTION
Opt roc-ansi into the guarded nightly merge policy from lukewilliamboswell/roc-automation#2 as the initial one-repository trial. Pin both shared workflows to the tested full SHA and set `auto_merge: true`.

The merge job performs no consumer checkout and reads policy through the API at the original default-branch event SHA. The controller only merges a verified bot pin commit after rechecking exact candidate validation and current branch state. The trial requires an active ruleset with PRs, signatures, strict test/build/bundle checks, no bypass, and zero required human approvals. Source and automation changes retain maintainer review as project policy. Nightly validation does not publish or deploy.

Validation: shared controller's 27 regression tests, actionlint, and Python/Actions CodeQL pass; local consumer configuration check passes. Consumer CI and the first live bot merge will verify the integration. Document the review/Scorecard tradeoff and how to disable the trial.

The trial ruleset is active: https://github.com/lukewilliamboswell/roc-ansi/rules/22403604. It enforces signatures, PRs, strict test/build/bundle checks, blocks deletion/force pushes, and grants no bypass. The shared PR is merged and CodeQL reports the checkout findings fixed.
