### PR TITLE
Report verified nightly checks on the bot PR

### DIFF
--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,10 +7,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `8412219c66c23f2ebdc54adf15dc28a00832c5ff`.
+The caller workflows pin shared code to `55d05b2e689a70fb668aa73ae61294b17126f850`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/8412219c66c23f2ebdc54adf15dc28a00832c5ff/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/55d05b2e689a70fb668aa73ae61294b17126f850/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
 GITHUB_TOKEN run. Keep default token permissions read-only. The updater never approves PRs and receives no protection bypass. This repository
 opts into automatic merging of validated compiler-pin PRs as the initial trial.
@@ -24,7 +24,7 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/8412219c66c23f2ebdc54adf15dc28a00832c5ff/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/55d05b2e689a70fb668aa73ae61294b17126f850/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.
 

--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -7,10 +7,10 @@ after the upstream 09:00 UTC build. Late publication can wait until the next day
 repository's validation workflows, including their validation-only release paths.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
-The caller workflows pin shared code to `8691138c0aab4a7509e3b489e7dff7d91816264f`.
+The caller workflows pin shared code to `8412219c66c23f2ebdc54adf15dc28a00832c5ff`.
 Dependabot proposes reviewed updates to Actions/workflow references.
 
-Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/8691138c0aab4a7509e3b489e7dff7d91816264f/docs/integration.md)
+Follow the shared [integration and permissions guide](https://github.com/lukewilliamboswell/roc-automation/blob/8412219c66c23f2ebdc54adf15dc28a00832c5ff/docs/integration.md)
 for the PR-creation setting, action allowlists, required checks, and first live
 GITHUB_TOKEN run. Keep default token permissions read-only. The updater never approves PRs and receives no protection bypass. This repository
 opts into automatic merging of validated compiler-pin PRs as the initial trial.
@@ -24,7 +24,7 @@ The shared repository owns the controller regression suite. Project tests remain
 in this repository and run on the exact candidate commit. Scheduled bot-token
 acceptance must be verified after merge; file changes alone cannot prove it.
 
-Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/8691138c0aab4a7509e3b489e7dff7d91816264f/docs/openssf.md)
+Use the shared [OpenSSF rollout checklist](https://github.com/lukewilliamboswell/roc-automation/blob/8412219c66c23f2ebdc54adf15dc28a00832c5ff/docs/openssf.md)
 to record project-specific evidence. This integration does not establish badge
 compliance or change repository settings.
 
@@ -59,3 +59,10 @@ inspect the updater run and retry manually after resolving the cause.
 This opts into unattended dependency updates, not automated human review. It can
 reduce OpenSSF Scorecard's Code-Review score; it does not establish or invalidate
 the passing Best Practices badge by itself. See the shared OpenSSF guidance.
+
+
+The validation controller mirrors the real required jobs as commit statuses on
+the candidate (pending, then success after verification). This lets GitHub enforce
+the required checks even when dispatched runs are not associated with a bot PR.
+Only that controller receives `statuses: write`; the merge job independently
+checks the underlying runs and jobs and cannot write statuses.

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@8691138c0aab4a7509e3b489e7dff7d91816264f
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@8412219c66c23f2ebdc54adf15dc28a00832c5ff

--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@8412219c66c23f2ebdc54adf15dc28a00832c5ff
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@55d05b2e689a70fb668aa73ae61294b17126f850

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -16,4 +16,4 @@ jobs:
       pull-requests: write
       actions: write
       statuses: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@8412219c66c23f2ebdc54adf15dc28a00832c5ff
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@55d05b2e689a70fb668aa73ae61294b17126f850

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -15,4 +15,5 @@ jobs:
       contents: write
       pull-requests: write
       actions: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@8691138c0aab4a7509e3b489e7dff7d91816264f
+      statuses: write
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@8412219c66c23f2ebdc54adf15dc28a00832c5ff


### PR DESCRIPTION
The first automatic-merge trial validated the compiler successfully, but GitHub's strict rules could not associate the dispatched checks with the bot PR and rejected the merge.

Use the shared fix from lukewilliamboswell/roc-automation#3 and add `statuses: write` to the caller ceiling. Only the validation controller receives that permission: it publishes pending statuses, then mirrors the real successful required jobs onto the exact candidate. The merge job independently checks run/job evidence and retains no status-write access. The existing three required checks, signatures, strict base requirements, and no-bypass rules remain enforced.

Validation: 31 shared controller tests and local actionlint pass; the consumer configuration check passes. Consumer CI and a fresh live updater run will verify the integration.


Live acceptance completed:
- All four updater phases passed: https://github.com/lukewilliamboswell/roc-ansi/actions/runs/34059965253.
- The Actions bot merged replacement nightly PR #43 (the stale #37 was closed during branch refresh): https://github.com/lukewilliamboswell/roc-ansi/pull/43.
- Merge commit `242e5ed7b9f8902606030a356b4ceed889d2f501` is verified and changes only `.roc-version`.
- GitHub rule suite `3966827274` passed for the Actions bot with the active strict rules and no bypass.
- A subsequent updater run completed successfully with validation/report/merge skipped and no new update: https://github.com/lukewilliamboswell/roc-ansi/actions/runs/34060098146.
- The shared repository's default branch has no open CodeQL alerts.
