### PR TITLE
Update all Roc nightly compiler pins

### DIFF
--- a/.github/ROC_NIGHTLY.md
+++ b/.github/ROC_NIGHTLY.md
@@ -3,10 +3,11 @@
 This repository checks once daily at 13:07 UTC, about four hours
 after the upstream 09:00 UTC build. Late publication can wait until the next day.
 
-The `roc` field in `package/main.roc` is the development compiler pin.
-`.github/roc-nightly.json` selects that root and this repository's validation
-workflows, including their validation-only release paths. Public example pins stay
-separate so they continue to document a tested released combination.
+The `roc` fields in `package/main.roc` and the public examples are the development
+compiler pins. `.github/roc-nightly.json` selects those roots and this repository's
+validation workflows, including their validation-only release paths. Keeping every
+application header on the same pin is required because Roc validates the header pin
+against the running compiler.
 The controller, its tests, and job permissions are maintained in
 [roc-automation](https://github.com/lukewilliamboswell/roc-automation).
 Dependabot proposes reviewed updates to the pinned Actions and shared workflows.

--- a/.github/roc-nightly.json
+++ b/.github/roc-nightly.json
@@ -4,7 +4,13 @@
     "release.yml"
   ],
   "compiler_roots": [
-    "package/main.roc"
+    "package/main.roc",
+    "examples/animals.roc",
+    "examples/colors.roc",
+    "examples/styles.roc",
+    "examples/tests.roc",
+    "examples/text-editor.roc",
+    "examples/tui-menu.roc"
   ],
   "auto_merge": true
 }

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ After validating package changes, dispatch the **Release** workflow with a new
 5. Creates a GitHub-signed `release-followup/VERSION` PR updating only example URLs.
 
 Review and merge that follow-up PR so `main` points to the newest working release.
-The nightly updater only auto-merges the compiler pin in `package/main.roc`; release follow-ups
+The nightly updater auto-merges the compiler pins in `package/main.roc` and the examples; release follow-ups
 remain reviewable PRs. Generated `roc docs` output is never committed. The follow-up creator can reuse an identical signed bot
 commit on retry, but refuses to overwrite a branch containing different work.
 PR and `nightly_validation` runs only validate; they never publish or deploy.

--- a/examples/animals.roc
+++ b/examples/animals.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	roc: "nightly-2026-09-07-14d9829",
+	roc: "nightly-2026-09-08-39a3f89",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.13.0/JXLM47L6CzrLXB5HBfqc27VnU6CD4jMm5Mk6dgbbovL.tar.zst",
 }
 

--- a/examples/colors.roc
+++ b/examples/colors.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	roc: "nightly-2026-09-07-14d9829",
+	roc: "nightly-2026-09-08-39a3f89",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.13.0/JXLM47L6CzrLXB5HBfqc27VnU6CD4jMm5Mk6dgbbovL.tar.zst",
 }
 

--- a/examples/styles.roc
+++ b/examples/styles.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	roc: "nightly-2026-09-07-14d9829",
+	roc: "nightly-2026-09-08-39a3f89",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.13.0/JXLM47L6CzrLXB5HBfqc27VnU6CD4jMm5Mk6dgbbovL.tar.zst",
 }
 

--- a/examples/tests.roc
+++ b/examples/tests.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	roc: "nightly-2026-09-07-14d9829",
+	roc: "nightly-2026-09-08-39a3f89",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.13.0/JXLM47L6CzrLXB5HBfqc27VnU6CD4jMm5Mk6dgbbovL.tar.zst",
 }
 

--- a/examples/text-editor.roc
+++ b/examples/text-editor.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	roc: "nightly-2026-09-07-14d9829",
+	roc: "nightly-2026-09-08-39a3f89",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.13.0/JXLM47L6CzrLXB5HBfqc27VnU6CD4jMm5Mk6dgbbovL.tar.zst",
 }
 

--- a/examples/tui-menu.roc
+++ b/examples/tui-menu.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/1.0.0/AnZoxzoGPtSGQ15EQh6pBeeaHJ7aizP9MQhK81dES3Uq.tar.zst",
-	roc: "nightly-2026-09-07-14d9829",
+	roc: "nightly-2026-09-08-39a3f89",
 	ansi: "https://github.com/lukewilliamboswell/roc-ansi/releases/download/0.13.0/JXLM47L6CzrLXB5HBfqc27VnU6CD4jMm5Mk6dgbbovL.tar.zst",
 }
 

--- a/package/main.roc
+++ b/package/main.roc
@@ -12,5 +12,5 @@ package
 		PieceTable,
 	]
 	{
-		roc: "nightly-2026-09-07-14d9829",
+		roc: "nightly-2026-09-08-39a3f89",
 	}


### PR DESCRIPTION
## Summary

- update every Roc application header to nightly-2026-09-08-39a3f89
- configure the nightly updater to bump package and example pins together
- document why all compiler pins must remain synchronized

## Validation

- full scripts/all_tests.py suite using nightly-2026-09-08-39a3f89
- 52 package tests
- all examples checked, tested, run, and built
- git diff --check
- JSON configuration validation