### PR TITLE
Update roc-automation workflow pins

### DIFF
--- a/.github/workflows/nightly-controller-tests.yml
+++ b/.github/workflows/nightly-controller-tests.yml
@@ -6,4 +6,4 @@ permissions:
   contents: read
 jobs:
   configuration:
-    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@b60d561cbd53c911b29238b30624827f8487113a
+    uses: lukewilliamboswell/roc-automation/.github/workflows/check-config.yml@19c8c1a3f780d648b85678bd31cf735d3584eb01

--- a/.github/workflows/update-roc-nightly.yml
+++ b/.github/workflows/update-roc-nightly.yml
@@ -16,4 +16,4 @@ jobs:
       pull-requests: write
       actions: write
       statuses: write
-    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@b60d561cbd53c911b29238b30624827f8487113a
+    uses: lukewilliamboswell/roc-automation/.github/workflows/update-roc-nightly.yml@19c8c1a3f780d648b85678bd31cf735d3584eb01


### PR DESCRIPTION
Pins both shared nightly workflows to the signed roc-automation revision 19c8c1a3f780d648b85678bd31cf735d3584eb01, which hardens nightly updates across compiler-root configuration changes.